### PR TITLE
Fix/dc 139 wptl1 long messages still saving to database

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -2,8 +2,8 @@ import asyncio
 import json
 import time
 import uuid
-from urllib.parse import unquote
 from typing import Any, Dict, Literal
+from urllib.parse import unquote
 
 from chainlit.action import Action
 from chainlit.auth import get_current_user, require_login
@@ -23,6 +23,8 @@ from chainlit.types import (
     UIMessagePayload,
 )
 from chainlit.user_session import user_sessions
+
+MAX_UI_MESSAGE_LENGTH = 9000
 
 
 def restore_existing_session(sid, session_id, emit_fn, emit_call_fn):
@@ -267,9 +269,23 @@ async def process_message(session: WebsocketSession, payload: UIMessagePayload):
         await context.emitter.task_end()
 
 
+def is_ui_message_valid(payload: UIMessagePayload) -> bool:
+    content = payload.get('message', {}).get('output', '')
+
+    if len(content) > MAX_UI_MESSAGE_LENGTH:
+        logger.error("Message of length {} sent to socket".format(len(content)))
+        return False
+
+    return True
+
+
 @socket.on("ui_message")
 async def message(sid, payload: UIMessagePayload):
     """Handle a message sent by the User."""
+
+    if not is_ui_message_valid(payload):
+        return
+
     session = WebsocketSession.require(sid)
 
     task = asyncio.create_task(process_message(session, payload))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -129,7 +129,6 @@ function App() {
         }}
       />
       <Toaster
-        className="toast"
         position="top-right"
         toastOptions={{
           style: {

--- a/frontend/src/components/organisms/chat/inputBox/index.tsx
+++ b/frontend/src/components/organisms/chat/inputBox/index.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from 'api/auth';
 import { memo, useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
+import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Box } from '@mui/material';
@@ -17,7 +18,6 @@ import { inputHistoryState } from 'state/userInputHistory';
 
 import Input from './input';
 import WaterMark from './waterMark';
-import {toast} from "sonner";
 
 interface Props {
   fileSpec: FileSpec;
@@ -45,21 +45,17 @@ const InputBox = memo(
     const { sendMessage, replyMessage } = useChatInteract();
     // const tokenCount = useRecoilValue(tokenCountState);
 
-    const validateMessage = (msg: string): boolean => {
-      if (msg && msg.length > maxMessageLength) {
-        const errorMsg = `The message is too long, please reduce to ` +
-          `${maxMessageLength} characters.`;
-        toast.error(errorMsg);
-        return false;
-      }
-
-      return true;
-    }
+    const isMessageValid = (msg: string) =>
+      msg && msg.length <= maxMessageLength;
 
     const onSubmit = useCallback(
       async (msg: string, attachments?: IAttachment[]) => {
-        if (!validateMessage(msg)) {
-          return
+        if (!isMessageValid(msg)) {
+          const errorMsg =
+            `The message is too long, please reduce to ` +
+            `${maxMessageLength} characters.`;
+          toast.error(errorMsg);
+          return;
         }
 
         const message: IStep = {
@@ -100,8 +96,8 @@ const InputBox = memo(
 
     const onReply = useCallback(
       async (msg: string) => {
-        if (!validateMessage(msg)) {
-          return
+        if (!isMessageValid(msg)) {
+          return;
         }
 
         const message: IStep = {

--- a/frontend/src/components/organisms/chat/inputBox/index.tsx
+++ b/frontend/src/components/organisms/chat/inputBox/index.tsx
@@ -17,6 +17,7 @@ import { inputHistoryState } from 'state/userInputHistory';
 
 import Input from './input';
 import WaterMark from './waterMark';
+import {toast} from "sonner";
 
 interface Props {
   fileSpec: FileSpec;
@@ -38,13 +39,29 @@ const InputBox = memo(
   }: Props) => {
     const layoutMaxWidth = useLayoutMaxWidth();
     const setInputHistory = useSetRecoilState(inputHistoryState);
+    const maxMessageLength = 9000;
 
     const { user } = useAuth();
     const { sendMessage, replyMessage } = useChatInteract();
     // const tokenCount = useRecoilValue(tokenCountState);
 
+    const validateMessage = (msg: string): boolean => {
+      if (msg && msg.length > maxMessageLength) {
+        const errorMsg = `The message is too long, please reduce to ` +
+          `${maxMessageLength} characters.`;
+        toast.error(errorMsg);
+        return false;
+      }
+
+      return true;
+    }
+
     const onSubmit = useCallback(
       async (msg: string, attachments?: IAttachment[]) => {
+        if (!validateMessage(msg)) {
+          return
+        }
+
         const message: IStep = {
           threadId: '',
           id: uuidv4(),
@@ -83,6 +100,10 @@ const InputBox = memo(
 
     const onReply = useCallback(
       async (msg: string) => {
+        if (!validateMessage(msg)) {
+          return
+        }
+
         const message: IStep = {
           threadId: '',
           id: uuidv4(),


### PR DESCRIPTION
Render toast when user input has error
Remove 'toast' class name from Toaster provider as it clashes with SGDS's toast class name which prevents it from rendering
